### PR TITLE
Improvements and features (pure iframe option, viewport size simulation, long iframes for synced scrolling)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -208,6 +208,7 @@
   bottom: 0;
   background-color: rgba(0, 0, 0, 0.5);
   display: flex;
+  z-index: 2;
   justify-content: center;
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -101,12 +101,6 @@
   width: 100%;
 }
 
-#main-app label {
-  color: #727272;
-  font-size: 14px;
-  margin-bottom: 20px;
-}
-
 /* Component styles */
 
 .image-comparison-tool {
@@ -139,6 +133,7 @@
   border-radius: 4px;
   border: 1px solid #e3e3e3;
   background: #fff;
+  transform-origin: 0 0;
 }
 
 .preview-top-bar {

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -110,7 +110,7 @@ function Modal(props) {
 
     useEffect(() => {
         function keyHandler(event) {
-            // don't mess with the keyboard is popover is open, the user is typing
+            // don't mess with the keyboard when popover is open, the user is typing
             if(!popoverOpen) {
                 if (event.key === 'Enter') {
                     handleAccept();

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -40,6 +40,7 @@ const Skip = (props) => {
 
 function Modal(props) {
     const [newData, setNewData] = useState([...props.parsedData])
+    const [viewportWidth, setViewportWidth] = useState(1920);
     const [activeData, setActiveData] = useState(0);
 
     const handleAccept = () => {
@@ -111,6 +112,18 @@ function Modal(props) {
     return (
         <div id='modal'>
             <h2>Compare these pages!</h2>
+            {!props.usemShots && <div>
+                <label>
+                    <p>Viewport width ({viewportWidth}px)</p>
+                    <select value={viewportWidth} onChange={event => setViewportWidth(Number(event.currentTarget.value))}>
+                        <option value="320">Apple iPhone 4</option>
+                        <option value="375">Apple iPhone X</option>
+                        <option value="768">Apple iPad Air</option>
+                        <option value="1920">Desktop</option>
+                        <option value="5120">Retina</option>
+                    </select>
+                </label>
+            </div>}
             <div>
                 <div id="status">
                     <span id="status-text"></span>
@@ -130,6 +143,8 @@ function Modal(props) {
                     activeData={activeData}
                     oldUrl={newData[activeData].oldUrl}
                     newUrl={newData[activeData].newUrl}
+                    usemShots={props.usemShots}
+                    viewportWidth={viewportWidth}
                 />
                 <Skip onSkip={handleSkip}/>
                 <Download onDownload={handleDownload}/>

--- a/src/components/Popup.js
+++ b/src/components/Popup.js
@@ -23,6 +23,7 @@ export default function Popup(props) {
                         cols="100" 
                         onChange={handleOnChange}
                         value={comment}
+                        autoFocus
                     ></textarea>
                 </form>
                 <div className="popup-actions">

--- a/src/components/SitePreview.js
+++ b/src/components/SitePreview.js
@@ -36,6 +36,8 @@ const Preview = (props) => {
         </div>
         <div
           ref={containerRef}
+          // the browser still thinks the iframe is 10000px tall, doesn't recognize the scale transform, so we shrink the div according to the scale factor
+          style={{height: 10000 * scaleFactor, overflow: 'hidden'}}
         >
           <iframe
             key={iframeKey}

--- a/src/components/SitePreview.js
+++ b/src/components/SitePreview.js
@@ -1,49 +1,81 @@
-import generateMShotsUrl from "../lib/mShots"
-import { useState } from "react";
+import generateMShotsUrl from '../lib/mShots';
+import { useEffect, useState, useRef } from 'react';
 
 const Title = (props) => {
-    return (
-        <span>
-          <strong>PAGE {props.index}: </strong>
-          <a href={props.url} target="_blank" rel="noreferrer">{props.url}</a>
-        </span>
-    )
-}
+  return (
+    <span>
+      <strong>PAGE {props.index}: </strong>
+      <a href={props.url} target="_blank" rel="noreferrer">
+        {props.url}
+      </a>
+    </span>
+  );
+};
 
 const Preview = (props) => {
-	// We need a way to force the iframe to remount in the case where mShots isn't ready and has redirected the iframe.
-	// Easiest way is the key attribute and bumping it with state!
-	// A bit hacky, but probably our best bet given the weird use case.
-	const [iframeKey, setIframeKey] = useState(0);
-	const handleReload = () => setIframeKey(iframeKey + 1);
-
+    // We need a way to force the iframe to remount in the case where mShots isn't ready and has redirected the iframe.
+    // Easiest way is the key attribute and bumping it with state!
+    // A bit hacky, but probably our best bet given the weird use case.
+    const [iframeKey, setIframeKey] = useState(0);
+    const [scaleFactor, setScaleFactor] = useState(1);
+    const handleReload = () => setIframeKey(iframeKey + 1);
+    const containerRef = useRef();
+  
+    useEffect(() => {
+      if(containerRef.current) {
+        // scale the iframe to fit the container while simulating the desired viewport width
+        setScaleFactor(containerRef.current.getBoundingClientRect().width / props.viewportWidth);
+      }
+    }, [props.scrollValue, props.viewportWidth]);
+  
     return (
-        <div className="column">
-			<div className="preview-top-bar">
-				<Title {...props}></Title>
-				<button onClick={handleReload}>Reload</button>
-			</div>
-            <iframe key={iframeKey} title="preview-0" className="preview" src={props.mShotsUrl} width="100%" height="500" />
+      <div className="column">
+        <div className="preview-top-bar">
+          <Title {...props}></Title>
+          <button onClick={handleReload}>Reload</button>
         </div>
-    )
+        <div
+          ref={containerRef}
+        >
+          <iframe
+            key={iframeKey}
+            title="preview-0"
+            className="preview"
+            src={props.mShotsUrl}
+            width={props.viewportWidth}
+            // use a big value to ensure the iframe is tall enough
+            // this way, both iframes will fit on the screen, and will scroll together lock-step by simply scrolling the page itself
+            height="10000"
+            style={{transform: `scale(${scaleFactor})`}}
+          />
+        </div>
+      </div>
+    );
+  };
+
+function SitePreview({activeData, oldUrl, usemShots, newUrl, viewportWidth}) {
+  let index = activeData + 1;
+  
+  return (
+    <div id="preview-all">
+      <Preview
+        index={index}
+        url={oldUrl}
+        mShotsUrl={
+          usemShots ? generateMShotsUrl(oldUrl) : oldUrl
+        }
+        viewportWidth={viewportWidth}
+      />
+      <Preview
+        index={index}
+        url={newUrl}
+        mShotsUrl={
+          usemShots ? generateMShotsUrl(newUrl) : newUrl
+        }
+        viewportWidth={viewportWidth}
+      />
+    </div>
+  );
 }
-
-function SitePreview(props) {
-    let index = props.activeData + 1;
-    return (
-        <div id="preview-all">
-            <Preview 
-                index={index}
-                url={props.oldUrl}
-                mShotsUrl={generateMShotsUrl(props.oldUrl)}
-            />
-            <Preview 
-                index={index}
-                url={props.newUrl}
-                mShotsUrl={generateMShotsUrl(props.newUrl)}
-            />
-        </div>
-    )
-} 
 
 export default SitePreview;

--- a/src/lib/mShots.js
+++ b/src/lib/mShots.js
@@ -1,6 +1,7 @@
 function generateMShotsUrl(targetUrl) {
 	let url = new URL('https://s0.wp.com/mshots/v1/');
-	url.pathname = url.pathname + targetUrl;
+	url.pathname = url.pathname + encodeURIComponent(targetUrl);
+	url.searchParams.append('vpw', '1920');
 	url.searchParams.append('screen_height', '3200');
 	return url.href;
 }


### PR DESCRIPTION
Hi everyone!

Thank you so much for this tool. We just need some changes to get this to work. Sadly, `mshots` doesn't support theme previewing (because only auth'ed users can preview themes). This fixes that by using vanilla iframes.

⚠️ Sorry for different editor settings, you can ignore white space while reviewing by adding `?w=1` to the diff URL.

#### Changes
1. **Pure iframe option**: This allows the user to opt for using just an iframe without any screen shooting.
2. **viewport size simulation**: This is an old iframe trick. To set the iframe to the viewport size you want, then scaling it using `transform: scale`. I scale the iframe to fit its parent perfectly.
3. **Long iframes**: first I had some fancy JS to sync the scrolling of the two iframes, then realized if they're long, they'll be synced automatically, so I lengthened them.
4. **Keyboard navigation**: This adds arrows for navigation, and enter for accept, and backspace to reject.

### Testing this

#### Testing without mshots
1. Run this by running `yarn start`.
2. Make sure you're proxied.
3. Go to the main page and untick `use mshots`.
5. Upload a CSV file with URLs. Get it from p1673867435942369-slack-C02T4NVL4JJ.
6. Test that the iframes both load and you can compare. 
7. Test the viewport simulation feature.

#### Regression testing (with mshots)
1. Tick mshots on the first page
2. Upload a CSV.
3. Previewing should work.
5. Viewport simulation should be hidden.
